### PR TITLE
Fix input text color when in android dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React Native Prompt
 
-[![npm version](https://badge.fury.io/js/%40powerdesigninc%2Freact-native-prompt.svg)](https://badge.fury.io/js/%40powerdesigninc%2Freact-native-prompt)
+[![npm version](https://badge.fury.io/js/%40rogermiret%2Freact-native-prompt.svg)](https://badge.fury.io/js/%40rogermiret%2Freact-native-prompt)
 
 This package helps you to use Prompt Dialog cross platform iOS(Alert.prompt) and Android(Dialog).
 
@@ -45,9 +45,9 @@ Use the same way as [`AlertIOS.prompt`](https://reactnative.dev/docs/alertios#pr
 
 ```bash
 # with npm
-npm install @powerdesigninc/react-native-prompt
+npm install @rogermiret/react-native-prompt
 # with yarn
-yarn add @powerdesigninc/react-native-prompt
+yarn add @rogermiret/react-native-prompt
 ```
 
 ### React Native >= v0.60
@@ -57,13 +57,13 @@ you don't need to link anything.
 ### React Native < v0.60, Manual linking
 
 ```
-react-native link @powerdesigninc/react-native-prompt
+react-native link @rogermiret/react-native-prompt
 ```
 
 ## Example
 
 ```tsx
-import prompt from "@powerdesigninc/react-native-prompt";
+import prompt from "@rogermiret/react-native-prompt";
 
 const App = () => {
   return (

--- a/android/src/main/res/layout/dialog.xml
+++ b/android/src/main/res/layout/dialog.xml
@@ -34,7 +34,8 @@
     android:layout_marginVertical="@dimen/content_input_space"
     android:background="@drawable/input_background"
     android:textCursorDrawable="@drawable/input_cursor"
-    android:textSize="@dimen/input" />
+    android:textSize="@dimen/input"
+    android:textColor="@color/text" />
 
   <View
     android:layout_width="match_parent"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rogermiret/react-native-prompt",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "React Native Prompt",
   "main": "index.ts",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@powerdesigninc/react-native-prompt",
-  "version": "0.1.2",
+  "name": "@rogermiret/react-native-prompt",
+  "version": "0.1.3",
   "description": "React Native Prompt",
   "main": "index.ts",
   "keywords": [
@@ -23,12 +23,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/powerdesigninc/react-native-prompt.git"
+    "url": "git://github.com/rogerxaic/react-native-prompt.git"
   },
   "bugs": {
-    "url": "https://github.com/powerdesigninc/react-native-prompt/issues"
+    "url": "https://github.com/rogerxaic/react-native-prompt/issues"
   },
-  "homepage": "https://github.com/powerdesigninc/react-native-prompt",
+  "homepage": "https://github.com/rogerxaic/react-native-prompt",
   "devDependencies": {
     "@types/react-native": "^0.62.2",
     "typescript": "^3.8.3"


### PR DESCRIPTION
The text will be white on an Android in dark mode as the system expects the background to be black/dark. Since the background is white (as per the code), it results in white text on a white background, which is unreadable.